### PR TITLE
Allow me to send payment request via a proxy.

### DIFF
--- a/lib/sage_pay/server/command.rb
+++ b/lib/sage_pay/server/command.rb
@@ -7,7 +7,7 @@ module SagePay
 
       self.vps_protocol = "2.23"
 
-      attr_accessor :mode, :vendor, :vendor_tx_code
+      attr_accessor :mode, :vendor, :vendor_tx_code, :http_proxy
 
       validates_presence_of :vps_protocol, :mode, :tx_type, :vendor,
         :vendor_tx_code
@@ -81,7 +81,15 @@ module SagePay
         request = Net::HTTP::Post.new(parsed_uri.request_uri)
         request.form_data = post_params
 
-        http = Net::HTTP.new(parsed_uri.host, parsed_uri.port)
+        if http_proxy
+          uri = URI.parse(http_proxy)
+          proxy_user, proxy_pass = uri.userinfo.split(/:/) if uri.userinfo
+          http_client = Net::HTTP::Proxy(uri.host, uri.port, proxy_user, proxy_pass)
+        else
+          http_client = Net::HTTP
+        end
+
+        http = http_client.new(parsed_uri.host, parsed_uri.port)
 
         if parsed_uri.scheme == "https"
           http.use_ssl = true


### PR DESCRIPTION
Hey, I've got a small patch to allow HTTP Proxy support, so those of us without a static IP, can use the static IP of our proxy server.

The rake tasks are passing for me, but I'm struggling to think of a good way of testing the new feature. I've manually tested it, but that test requires using my SagePay and Proximo accounts. Let me know if you'd like me if you can think of a neat way of doing it, without needing an account on a proxy server, and a specially set up sage pay account.